### PR TITLE
chore: add other db tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,8 @@
-FROM alpine
-RUN apk add --no-cache mysql-client bash grep sed
+FROM alpine:3.18.3
+RUN apk add --no-cache bash \
+	grep \
+	sed \
+	mysql-client \
+	mongodb-tools \
+	postgresql-client \
+	&& rm -rf /var/cache/apk/*


### PR DESCRIPTION
Maybe we could fork/move this to `uselagoon` even maybe as part of `lagoon-images` ?